### PR TITLE
Clarifying that if user downloaded from Tech Hub, it includes sbt dist

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # Play Hello World Web Tutorial for Java
 
-To follow the steps in this tutorial, you will need the correct version of Java and a build tool. You can build Play projects with sbt or Gradle. Since sbt works particularly well with Play, we recommend trying this example with sbt. The template requires:
+To follow the steps in this tutorial, you will need the correct version of Java and a build tool. You can build Play projects with any Java build tool. Since sbt takes advantage of Play features such as auto-reload, the tutorial describes how to build the project with sbt. 
+
+Prerequisites include:
 
 * Java Software Developer's Kit (SE) 1.8 or higher
-* sbt 0.13.15 or higher (we recommend 1.2.3)
+* sbt 0.13.15 or higher (we recommend 1.2.3) Note: if you downloaded this project as a zip file from https://developer.lightbend.com, the file includes an sbt distribution for your convenience.
 
 To check your Java version, enter the following in a command window:
 


### PR DESCRIPTION
Similar to the change for the Scala example.